### PR TITLE
fix: add missing categories

### DIFF
--- a/src/common/glossary.ts
+++ b/src/common/glossary.ts
@@ -4,7 +4,7 @@ import { Reason } from './types'
 interface TreeViewMeta {
   label: string
   icon?: string
-  order: number
+  order?: number
 }
 
 export const SEVERITY_LEVEL_MAP: { [key in SeverityLevel]: TreeViewMeta } = {
@@ -34,6 +34,8 @@ export type CodePatternCategory =
   | 'Performance'
   | 'Complexity'
   | 'Documentation'
+  | 'BestPractice'
+  | 'Comprehensibility'
 
 export const CATEGORY_LEVEL_MAP: { [key in CodePatternCategory]: TreeViewMeta } = {
   ErrorProne: {
@@ -44,7 +46,7 @@ export const CATEGORY_LEVEL_MAP: { [key in CodePatternCategory]: TreeViewMeta } 
   CodeStyle: {
     label: 'Code Style',
     icon: 'code',
-    order: 7,
+    order: 9,
   },
   UnusedCode: {
     label: 'Unused Code',
@@ -73,6 +75,16 @@ export const CATEGORY_LEVEL_MAP: { [key in CodePatternCategory]: TreeViewMeta } 
   },
   Documentation: {
     label: 'Documentation',
+    icon: 'code',
+    order: 10,
+  },
+  BestPractice: {
+    label: 'Best Practice',
+    icon: 'code',
+    order: 7,
+  },
+  Comprehensibility: {
+    label: 'Comprehensibility',
     icon: 'code',
     order: 8,
   },

--- a/src/common/parseGitRemote.ts
+++ b/src/common/parseGitRemote.ts
@@ -10,7 +10,7 @@ const validProviders: Record<string, 'gh' | 'gl' | 'bb'> = {
  * @returns
  */
 export const parseGitRemote = (remoteUrl: string) => {
-  const pattern = /^.*(github|gitlab|bitbucket)\.(?:com|org)[:|/](.+?)\/(.+?).git$/
+  const pattern = /^.*(github|gitlab|bitbucket)\.(?:com|org)[:|/](.+?)\/(.+?)(\.git)?$/
   const match = remoteUrl.match(pattern)
 
   if (!match) {

--- a/src/views/nodes/BranchIssuesTreeNode.ts
+++ b/src/views/nodes/BranchIssuesTreeNode.ts
@@ -84,10 +84,11 @@ export class BranchIssuesTreeGroupByCategoryNode extends BranchIssuesTreeNode {
     return Object.entries(groups)
       .sort(
         ([a], [b]) =>
-          CATEGORY_LEVEL_MAP[a as CodePatternCategory].order - CATEGORY_LEVEL_MAP[b as CodePatternCategory].order
+          (CATEGORY_LEVEL_MAP[a as CodePatternCategory]?.order || 1000) -
+          (CATEGORY_LEVEL_MAP[b as CodePatternCategory]?.order || 1000)
       )
       .map(([category, items]) => {
-        const meta = CATEGORY_LEVEL_MAP[category as CodePatternCategory]
+        const meta = CATEGORY_LEVEL_MAP[category as CodePatternCategory] || { label: category, icon: 'tag' }
         return new BranchIssuesTreeCategoryNode(meta.label, meta.icon, items, this._baseUri)
       })
   }
@@ -105,7 +106,11 @@ export class BranchIssuesTreeGroupBySeverityNode extends BranchIssuesTreeNode {
     const groups = groupBy(this._allIssues, ({ commitIssue: i }) => i.patternInfo.severityLevel)
 
     return Object.entries(groups)
-      .sort(([a], [b]) => SEVERITY_LEVEL_MAP[a as SeverityLevel].order - SEVERITY_LEVEL_MAP[b as SeverityLevel].order)
+      .sort(
+        ([a], [b]) =>
+          (SEVERITY_LEVEL_MAP[a as SeverityLevel]?.order || 1000) -
+          (SEVERITY_LEVEL_MAP[b as SeverityLevel]?.order || 1000)
+      )
       .map(([severity, items]) => {
         const meta = SEVERITY_LEVEL_MAP[severity as SeverityLevel]
         return new BranchIssuesTreeCategoryNode(meta.label, meta.icon, items, this._baseUri)


### PR DESCRIPTION
- There were new categories and the extension was failing when these categories were present (only when trying to list all issues inside a category)
- Also updated the code so it doesn't fail in the future if there are new unknown categories
- Updated the regular expression to parse the remote to use the same one we use in the intellij extension (the previous one had some issues testing some repos in that extension)