### PR TITLE
fix: Make VSX job not a bloker for the workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Publish to Visual Studio Marketplace
         run: vsce publish --packagePath "./releases/codacy-$RELEASE_VERSION.vsix" --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }}
       - name: Publish to Open VSX Registry
+        continue-on-error: true
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           preRelease: false


### PR DESCRIPTION
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error 