### PR TITLE
feat: send URI scheme on auth

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -40,20 +40,22 @@ export const signIn = async () => {
 
   // Get the first open repository
   const repository = api?.repositories[0]
-  const params = [`scheme=${scheme}`]
+  const params = new URLSearchParams({ scheme })
 
   if (repository) {
     const remoteUrl = repository.state.remotes[0]?.fetchUrl || repository.state.remotes[0]?.pushUrl
     if (remoteUrl) {
       try {
         const { provider, organization, repository: repoName } = parseGitRemote(remoteUrl)
-        params.push(`provider=${provider}`, `organization=${organization}`, `repository=${repoName}`)
+        params.set('provider', provider)
+        params.set('organization', organization)
+        params.set('repository', repoName)
       } catch (e) {
         Logger.error(`Error parsing git remote: ${e}`)
       }
     }
   }
   const editor = detectEditor()
-  const uri = vscode.Uri.parse(`${Config.baseUri}/auth/${editor}?${params.join('&')}`)
+  const uri = vscode.Uri.parse(`${Config.baseUri}/auth/${editor}?${params.toString()}`)
   await vscode.env.openExternal(uri)
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -34,24 +34,26 @@ export const detectEditor = (): IDE => {
 
 export const signIn = async () => {
   const gitExtension = vscode.extensions.getExtension('vscode.git')?.exports
+  const scheme = vscode.env.uriScheme
+
   const api = gitExtension?.getAPI(1)
 
   // Get the first open repository
   const repository = api?.repositories[0]
-  let params = ''
+  const params = [`scheme=${scheme}`]
 
   if (repository) {
     const remoteUrl = repository.state.remotes[0]?.fetchUrl || repository.state.remotes[0]?.pushUrl
     if (remoteUrl) {
       try {
         const { provider, organization, repository: repoName } = parseGitRemote(remoteUrl)
-        params = `?provider=${provider}&organization=${organization}&repository=${repoName}`
+        params.push(`provider=${provider}`, `organization=${organization}`, `repository=${repoName}`)
       } catch (e) {
         Logger.error(`Error parsing git remote: ${e}`)
       }
     }
   }
   const editor = detectEditor()
-  const uri = vscode.Uri.parse(`${Config.baseUri}/auth/${editor}${params}`)
+  const uri = vscode.Uri.parse(`${Config.baseUri}/auth/${editor}?${params.join('&')}`)
   await vscode.env.openExternal(uri)
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ import Telemetry from './common/telemetry'
 import { decorateWithCoverage } from './views/coverage'
 import { APIState, Repository as GitRepository } from './git/git'
 import { configureMCP, createRules, isMCPConfigured } from './commands/configureMCP'
-import { installCodacyCLI, isCLIInstalled, updateCodacyCLI } from './commands/installAnalysisCLI'
+import { isCLIInstalled, updateCodacyCLI } from './commands/installAnalysisCLI'
 
 /**
  * Helper function to register all extension commands


### PR DESCRIPTION
Send URI scheme to later reuse in SPA. Will simplify how we build the link but also expand it to be able to be used with things like VSCode insiders:

VS Code Stable: vscode://
VS Code Insiders: vscode-insiders://
GitHub Codespaces: vscode-remote://
VSCodium: vscodium://
Cursor: cursor://
Windsurf: windsurf:// 
...

So we could manage all options, even the ones we don't know about yet