### PR TITLE
fix: Handle path name on windows with quotes CF-1754

### DIFF
--- a/src/cli/WinWSLCodacyCli.ts
+++ b/src/cli/WinWSLCodacyCli.ts
@@ -2,21 +2,22 @@ import { MacCodacyCli } from './MacCodacyCli'
 
 export class WinWSLCodacyCli extends MacCodacyCli {
   constructor(rootPath: string, provider?: string, organization?: string, repository?: string) {
-    const winRootPath = rootPath.startsWith('/mnt/') ? WinWSLCodacyCli.fromWSLPath(rootPath) : rootPath
+    const winRootPath =
+      rootPath.startsWith('/mnt/') || rootPath.startsWith("'/mnt/") ? WinWSLCodacyCli.fromWSLPath(rootPath) : rootPath
     super(winRootPath, provider, organization, repository)
   }
 
   private static toWSLPath(path: string): string {
     // Convert Windows path to WSL path
-    // Example: C:\Users\user\project -> /mnt/c/Users/user/project
-    const wslPath = path.replace(/\\/g, '/').replace(/^([a-zA-Z]):/, '/mnt/$1')
+    // Example: 'C:\Users\user\project' -> '/mnt/c/Users/user/project'
+    const wslPath = path.replace(/\\/g, '/').replace(/^'([a-zA-Z]):/, "'/mnt/$1")
     return wslPath
   }
 
   private static fromWSLPath(path: string): string {
-    // Convert WSL path to Windows path
-    // Example: /mnt/c/Users/user/project -> C:\Users\user\project
-    const windowsPath = path.replace(/^\/mnt\/([a-zA-Z])/, '$1:').replace(/\//g, '\\')
+    // Convert WSL path to Windows path while keeping quotes
+    // Example: '/mnt/c/Users/user/project' -> 'C:\Users\user\project'
+    const windowsPath = path.replace(/^'\/mnt\/([a-zA-Z])/, "'$1:").replace(/\//g, '\\')
     return windowsPath
   }
 


### PR DESCRIPTION
Windows started failing after: https://github.com/codacy/codacy-vscode-extension/pull/120/files#diff-4d1ce35c56f74ee76cac08de6e0d162f79cd3c525eea0686732b9a62e0366c1bL261 

CF-1754 