### PR TITLE
fix: Remove codacy cloud window when there is a pull request available

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
           "id": "codacy:cloud-status",
           "name": "Codacy Cloud",
           "icon": "$(library)",
-          "when": "codacy:hasProject",
+          "when": "codacy:hasProject && Codacy:PullRequestStateContext == NoPullRequest",
           "initialSize": 1,
           "collapsed": false
         },

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
       },
       {
         "view": "codacy:mcp",
-        "contents": "Set up Codacy MCP Server to get access to Codacy information from your agent.\n[Install MCP Server](command:codacy.configureMCP)\n\nTo control your AI generated code with [Codacy Guardrails](https://www.codacy.com/guardrails/), you need to be able to install the Codacy CLI (macOS, Linus, or Windows via WSL).",
+        "contents": "Set up Codacy MCP Server to get access to Codacy information from your agent.\n[Install MCP Server](command:codacy.configureMCP)\n\nTo control your AI generated code with [Codacy Guardrails](https://www.codacy.com/guardrails/), you need to be able to install the Codacy CLI (macOS, Linux, or Windows via WSL 2).",
         "when": "codacy:supportsMCP && !codacy:mcpConfigured && !codacy:canInstallCLI"
       },
       {
@@ -219,7 +219,7 @@
       },
       {
         "view": "codacy:cli",
-        "contents": "Codacy CLI is only available on Windows via [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).",
+        "contents": "Codacy CLI is only available on Windows via [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install).",
         "when": "codacy:windowsDetected && !codacy:canInstallCLI"
       },
       {


### PR DESCRIPTION
+ explicitly instruct the user to use WSL 2