### PR TITLE
feat: add dev mode setting CF-1890

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,6 +205,11 @@
       },
       {
         "view": "codacy:mcp",
+        "contents": "$(warning) Development mode is enabled. [Reinstall dependencies](command:codacy.installCLIDependencies).",
+        "when": "codacy:canInstallCLI && codacy:cliInstalled && codacy:devMode"
+      },
+      {
+        "view": "codacy:mcp",
         "contents": "$(warning) Codacy CLI not found. [Install CLI](command:codacy.installCLI)",
         "when": "codacy:supportsMCP && codacy:mcpConfigured && !codacy:cliInstalled && codacy:canInstallCLI && !codacy:cliInstalling"
       },
@@ -439,6 +444,12 @@
             "disabled"
           ],
           "default": "enabled"
+        },
+        "codacy.cli.devMode": {
+          "type": "boolean",
+          "title": "Enable development mode",
+          "description": "When enabled, the extension will no longer initialize the Codacy CLI automatically. Enabling this option may result in a degraded user experience.",
+          "default": false
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,6 +50,9 @@ const registerCommands = async (context: vscode.ExtensionContext, codacyCloud: C
     'codacy.installCLI': async () => {
       await codacyCloud.cli?.install()
     },
+    'codacy.installCLIDependencies': async () => {
+      await codacyCloud.cli?.installDependencies()
+    },
     'codacy.configureMCP': async () => {
       await configureMCP(codacyCloud.params)
     },
@@ -214,6 +217,15 @@ export async function activate(context: vscode.ExtensionContext) {
 
         // Update MCP config now that we have a token and perhaps a repository
         updateMCPConfig(codacyCloud.params)
+      })
+    )
+
+    // listen for workspace configuration changes to handle dev mode changes
+    context.subscriptions.push(
+      vscode.workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration('codacy.cli.devMode')) {
+          Config.updateDevMode()
+        }
       })
     )
 


### PR DESCRIPTION
- Adds a dev mode setting that stops the CLI from initialising and overwriting the codacy.yaml 
- Adds a warning about dev mode being enabled, with an action to reinstall dependencies for easier installation when a new tool is added

<img width="253" height="283" alt="Screenshot 2025-08-29 at 16 54 12" src="https://github.com/user-attachments/assets/083e11a9-4292-4e99-8f8f-97e0cf46143f" />
