### PR TITLE
fix: Skip delta issues without pull request shas OD-539

### DIFF
--- a/src/git/PullRequest.ts
+++ b/src/git/PullRequest.ts
@@ -151,6 +151,15 @@ export class PullRequest extends PullRequestInfo {
 
     // load PR delta issues
     this._issues = []
+
+    // a pull request Codacy couldn't resolve the commits of has nothing to diff
+    if (!this._headCommit || !this._baseCommit) {
+      Logger.debug(
+        `Skipping delta issues for pull request #${this._prWithAnalysis.pullRequest.number}: missing head or common ancestor commit`
+      )
+      return
+    }
+
     let nextCursor: string | undefined
     try {
       do {

--- a/src/test/suite/pullRequest/pullRequest.test.ts
+++ b/src/test/suite/pullRequest/pullRequest.test.ts
@@ -1,0 +1,99 @@
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { SinonSandbox, SinonStub, createSandbox } from 'sinon'
+import { PullRequest } from '../../../git/PullRequest'
+import { CodacyCloud, CodacyCloudState } from '../../../git/CodacyCloud'
+import { PullRequestWithAnalysis } from '../../../api/client'
+import { Api } from '../../../api'
+
+const HEAD_COMMIT_SHA = 'a'.repeat(40)
+const COMMON_ANCESTOR_COMMIT_SHA = 'b'.repeat(40)
+
+// the sha fields aren't in the vendored API spec yet (see OD-544), so the mock is built untyped
+const mockPullRequest = (shas: { headCommitSha?: string; commonAncestorCommitSha?: string }) =>
+  ({
+    isAnalysing: false,
+    meta: { analyzable: true },
+    pullRequest: {
+      id: 1,
+      number: 1,
+      updated: new Date().toISOString(),
+      status: 'open',
+      repository: 'repository',
+      title: 'Amazing pull request',
+      owner: { name: 'Owner', username: 'owner' },
+      gitHref: 'https://github.com/organization/repository/pull/1',
+      ...shas,
+    },
+  }) as unknown as PullRequestWithAnalysis
+
+const mockCodacyCloud = () =>
+  ({
+    state: CodacyCloudState.Loaded,
+    repository: { provider: 'gh', owner: 'organization', name: 'repository' },
+    expectCoverage: false,
+    rootUri: vscode.Uri.file('/repository'),
+    head: undefined,
+  }) as unknown as CodacyCloud
+
+suite('Pull Request Test Suite', () => {
+  let sinon: SinonSandbox
+  let listCommitDeltaIssues: SinonStub
+  let refreshed: Promise<unknown> | undefined
+
+  setup(() => {
+    sinon = createSandbox()
+
+    // the constructor kicks off refresh() without awaiting it, so grab the task it hands to the progress API
+    sinon.stub(vscode.window, 'withProgress').callsFake((_options, task) => {
+      refreshed = task(
+        { report: () => undefined },
+        new vscode.CancellationTokenSource().token
+      ) as unknown as Promise<unknown>
+      return refreshed as Thenable<unknown>
+    })
+    sinon.stub(vscode.commands, 'executeCommand').resolves()
+
+    listCommitDeltaIssues = sinon.stub(Api.Analysis, 'listCommitDeltaIssues')
+    sinon.stub(Api.Repository, 'getPullRequestQualitySettings').resolves({ data: { qualityGate: {} } })
+    sinon.stub(Api.Analysis, 'listPullRequestFiles').resolves({ data: [] })
+  })
+
+  teardown(() => {
+    sinon.restore()
+  })
+
+  test('fetches delta issues when both commit shas are present', async () => {
+    listCommitDeltaIssues.resolves({ data: [] })
+
+    const pullRequest = new PullRequest(
+      mockPullRequest({
+        headCommitSha: HEAD_COMMIT_SHA,
+        commonAncestorCommitSha: COMMON_ANCESTOR_COMMIT_SHA,
+      }),
+      mockCodacyCloud()
+    )
+    await refreshed
+
+    assert.strictEqual(listCommitDeltaIssues.callCount, 1)
+    assert.strictEqual(pullRequest.meta.headCommitSHA, HEAD_COMMIT_SHA)
+  })
+
+  test('skips delta issues and still loads the pull request when both commit shas are absent', async () => {
+    const pullRequest = new PullRequest(mockPullRequest({}), mockCodacyCloud())
+    await refreshed
+
+    assert.ok(listCommitDeltaIssues.notCalled)
+    assert.deepStrictEqual(pullRequest.issues, [])
+    assert.strictEqual(pullRequest.meta.headCommitSHA, undefined)
+    assert.strictEqual(pullRequest.meta.commonAncestorCommitSHA, undefined)
+  })
+
+  test('skips delta issues when only the common ancestor sha is absent', async () => {
+    const pullRequest = new PullRequest(mockPullRequest({ headCommitSha: HEAD_COMMIT_SHA }), mockCodacyCloud())
+    await refreshed
+
+    assert.ok(listCommitDeltaIssues.notCalled)
+    assert.deepStrictEqual(pullRequest.issues, [])
+  })
+})


### PR DESCRIPTION
## Changes

- `src/git/PullRequest.ts` — skip the delta issues request when the pull request has no head or common ancestor commit sha, instead of sending `undefined` path segments
- `src/test/suite/pullRequest/pullRequest.test.ts` — new test suite for `PullRequest` issue fetching

## Manual Testing

Regression only — the no-sha branch itself is not reachable until OD-464 lands and the API spec pin is bumped (OD-544), so this verifies the guard doesn't disturb the existing happy path.

**Type check** — `npm ci && npx tsc --noEmit`: clean, 0 errors. `eslint src --ext ts`: clean.

**Unit tests** — 45 passing, 0 failing:

```
Pull Request Test Suite
  ✔ fetches delta issues when both commit shas are present
  ✔ skips delta issues and still loads the pull request when both commit shas are absent
  ✔ skips delta issues when only the common ancestor sha is absent
```

**Mutation check** — forcing the guard always-on (`if (true)`) turns the run into 44 passing / 1 failing, the failure being `fetches delta issues when both commit shas are present`. Confirms the happy-path check can actually go red, then reverted.
